### PR TITLE
Add easyjson support

### DIFF
--- a/build_esi.sh
+++ b/build_esi.sh
@@ -36,13 +36,23 @@ git remote add upstream "https://${GH_TOKEN}@github.com/antihax/goesi.git"
 git fetch upstream
 git pull upstream HEAD
 go get -v
+go get golang.org/x/tools/cmd/goimports
+go get -u github.com/mailru/easyjson/...
 
 COUNTER=1
 while [ $COUNTER -lt 5 ]; do
     rm ./v$COUNTER/*
     rm ./v$COUNTER/docs/*
     set -e
-    java -jar ../swagger-esi-goclient/swagger-codegen-cli.jar generate -o ./v$COUNTER -t ../swagger-esi-goclient/template -l go -i https://esi.tech.ccp.is/v$COUNTER/swagger.json?datasource=tranquility -DpackageName=goesiv$COUNTER
+    # Generate models first and JSON code second because there is no easy way to glob for model files only
+    java -jar -Dmodels ./swagger-codegen-cli.jar generate -o ../goesi/v$COUNTER -t ./template -l go -i https://esi.tech.ccp.is/v$COUNTER/swagger.json?datasource=tranquility -DpackageName=goesiv$COUNTER
+    easyjson -noformat ../goesi/v$COUNTER/*.go
+    # Generate all the other files
+    java -jar ./swagger-codegen-cli.jar generate -o ../goesi/v$COUNTER -t ./template -l go -i https://esi.tech.ccp.is/v$COUNTER/swagger.json?datasource=tranquility -DpackageName=goesiv$COUNTER
+    # Fix slices of struct types
+    sed -i '' 's/REMOVEME\[\]//g' ../goesi/v$COUNTER/*.*
+    # Fix imports where needed (select encoding/json or easyjson)
+    goimports -w ../goesi/v$COUNTER
     let COUNTER=COUNTER+1 
     set +e
 done

--- a/build_local.sh
+++ b/build_local.sh
@@ -3,10 +3,19 @@
 COUNTER=1
 
 while [ $COUNTER -lt 5 ]; do
+    # Cleanup
     rm ../goesi/v$COUNTER/*
     rm ../goesi/v$COUNTER/docs/*
     set -e
+    # Generate models first and JSON code second because there is no easy way to glob for model files only
+    java -jar -Dmodels ./swagger-codegen-cli.jar generate -o ../goesi/v$COUNTER -t ./template -l go -i https://esi.tech.ccp.is/v$COUNTER/swagger.json?datasource=tranquility -DpackageName=goesiv$COUNTER
+    easyjson -noformat ../goesi/v$COUNTER/*.go
+    # Generate all the other files
     java -jar ./swagger-codegen-cli.jar generate -o ../goesi/v$COUNTER -t ./template -l go -i https://esi.tech.ccp.is/v$COUNTER/swagger.json?datasource=tranquility -DpackageName=goesiv$COUNTER
+    # Fix slices of struct types
+    sed -i '' 's/REMOVEME\[\]//g' ../goesi/v$COUNTER/*.*
+    # Fix imports where needed (select encoding/json or easyjson)
+    goimports -w ../goesi/v$COUNTER
     let COUNTER=COUNTER+1 
     set +e
 done

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strings"
 	"golang.org/x/net/context"
+
+	"github.com/mailru/easyjson"
 {{#imports}}	"{{import}}"
 {{/imports}}
 )
@@ -35,7 +37,17 @@ func (a *{{{classname}}}Service) {{{nickname}}}({{#authMethods}}ctx context.Cont
 		localVarFileName string
 		localVarFileBytes []byte
 {{#returnType}}
+		{{#isListContainer}}
+		{{#returnTypeIsPrimitive}}
 	 	successPayload  {{returnType}}
+		{{/returnTypeIsPrimitive}}
+		{{^returnTypeIsPrimitive}}
+		successPayload  REMOVEME{{returnType}}List
+		{{/returnTypeIsPrimitive}}
+		{{/isListContainer}}
+		{{^isListContainer}}
+	 	successPayload  {{returnType}}
+		{{/isListContainer}}
 {{/returnType}}
 	)
 
@@ -190,11 +202,16 @@ func (a *{{{classname}}}Service) {{{nickname}}}({{#authMethods}}ctx context.Cont
 		return {{#returnType}}successPayload, {{/returnType}}localVarHttpResponse, reportError(localVarHttpResponse.Status)
 	 }
 {{#returnType}}
-	
+	{{#returnTypeIsPrimitive}}
 	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
-	 	return {{#returnType}}successPayload, {{/returnType}}localVarHttpResponse, err
+	 	return successPayload, localVarHttpResponse, err
 	}
-
+	{{/returnTypeIsPrimitive}}
+	{{^returnTypeIsPrimitive}}
+	if err = easyjson.UnmarshalFromReader(localVarHttpResponse.Body, &successPayload); err != nil {
+	 	return successPayload, localVarHttpResponse, err
+	}
+	{{/returnTypeIsPrimitive}}
 {{/returnType}}
 
 	return {{#returnType}}successPayload, {{/returnType}}localVarHttpResponse, err

--- a/template/model.mustache
+++ b/template/model.mustache
@@ -4,8 +4,14 @@ package {{packageName}}
 import ({{/imports}}{{#imports}}
 	"{{import}}"{{/imports}}{{#imports}}
 )
-{{/imports}}{{#model}}{{#description}}
+{{/imports}}{{#model}}
+/* A list of {{classname}}. */
+//easyjson:json
+type {{classname}}List []{{classname}}
+
+{{#description}}
 /* {{{description}}} */{{/description}}
+//easyjson:json
 type {{classname}} struct {
 {{#vars}}
 	{{name}} {{{datatype}}} `json:"{{baseName}},omitempty"` {{#description}}/* {{{description}}} */{{/description}}


### PR DESCRIPTION
This PR adds [easyjson](https://github.com/mailru/easyjson) support for struct types and their slices. This should speed up parsing of large responses such as market data significantly. Parsing supported types via easyjson is done transparently. No changes to existing code are required to take advantage of the faster JSON processing. 
Primitive return types are still parsed via `encoding/json`. It might be possible to implement this using some complex mustache templating. I hope I correctly  modified the build scripts. The system used for building the client now needs `goimports`, `easyjson` and `sed`. Code for (un-)marshalling slices of the API's types is generated for `<TypeName>List` types defined like this:

```go
type ESITypeList []ESIType 
```

As these types are equivalent to the slice, they can be returned without altering the current function's signature. The build step involving `sed` is necessary because in the case of list types the unmodified type's name is not available in the template. E.g. you can only get `[]MyType` and there is no way to turn this into `MyTypeList` as you can't get rid of the `[]` in mustache unless you get it from a variable which you can't unless you modify the code generator. 
Generating the easyjson functions makes the build process take a lot longer (a couple of minutes vs. some seconds on my machine), however I think the gains in efficiency during runtime are worth it.
